### PR TITLE
Fix Fortnite sprite parser count mismatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "creeper-bot",
-  "version": "4.0.12",
+  "version": "4.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "creeper-bot",
-      "version": "4.0.12",
+      "version": "4.0.15",
       "license": "ISC",
       "dependencies": {
         "@discordjs/builders": "^0.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "creeper-bot",
-  "version": "4.0.14",
+  "version": "4.0.15",
   "engines": {
     "node": "22.x"
   },

--- a/src/Fortnite/FortniteSprites/FortniteSpriteCard.ts
+++ b/src/Fortnite/FortniteSprites/FortniteSpriteCard.ts
@@ -140,8 +140,8 @@ export class FortniteSpriteCard {
         ctx.stroke();
 
         try {
-            const response = await axios.get<ArrayBuffer>(variant.imageUrl, { responseType: "arraybuffer", timeout: 10000 });
-            const image = await loadImage(Buffer.from(response.data));
+            const imageBuffer = await this.fetchSpriteImage(variant.imageUrl);
+            const image = await loadImage(imageBuffer);
             const scale = Math.min((artSize - 42) / image.width, (artSize - 42) / image.height);
             const imageWidth = image.width * scale;
             const imageHeight = image.height * scale;
@@ -189,6 +189,36 @@ export class FortniteSpriteCard {
         ctx.textAlign = "right";
         ctx.fillText(family.displayName.toUpperCase(), 1130, 630);
         return canvas.toBuffer("image/png");
+    }
+
+    private async fetchSpriteImage(imageUrl: string): Promise<Buffer> {
+        let lastError: any;
+
+        for (const candidateUrl of this.getSpriteImageUrlCandidates(imageUrl)) {
+            try {
+                const response = await axios.get<ArrayBuffer>(candidateUrl, {
+                    responseType: "arraybuffer",
+                    timeout: 10000,
+                    headers: {
+                        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+                        "Accept": "image/webp,image/png,image/apng,image/*,*/*;q=0.8"
+                    }
+                });
+                return Buffer.from(response.data);
+            } catch (error) {
+                lastError = error;
+            }
+        }
+
+        throw lastError || new Error("Sprite image could not be loaded.");
+    }
+
+    private getSpriteImageUrlCandidates(imageUrl: string): string[] {
+        if (!imageUrl.includes("fortnite.gg")) return [imageUrl];
+
+        const webpUrl = imageUrl.replace(/\.(?:png|webp)(\?.*)?$/i, ".webp$1");
+        const pngUrl = imageUrl.replace(/\.(?:png|webp)(\?.*)?$/i, ".png$1");
+        return Array.from(new Set([webpUrl, imageUrl, pngUrl]));
     }
 
     private drawStat(ctx: any, label: string, value: string, x: number, y: number, accent: string): void {

--- a/src/Fortnite/FortniteSprites/FortniteSprites.ts
+++ b/src/Fortnite/FortniteSprites/FortniteSprites.ts
@@ -21,6 +21,7 @@ import * as path from "path";
 import * as crypto from "crypto";
 import type { Browser, Page } from "puppeteer";
 import https from "https";
+import { createCanvas, loadImage } from "@napi-rs/canvas";
 import { fetchSpriteData, SpriteDataFile, SpriteFamily, SpriteRarity, SpriteVariant, SpriteVariantName, stableSpriteDataJson, validateSpriteData } from "./spriteDataSource";
 import { createTrackedJob, registerComponent } from "../../runtimeDiagnostics";
 
@@ -111,6 +112,7 @@ const SPAWN_RATE_ICON_PATHS: Record<string, string> = {
     supplyDrop: path.join(process.cwd(), "assets", "drop-resized.png")
 };
 const SPRITE_ASSET_CACHE_DIR = path.join(process.cwd(), ".cache", "fortnite-sprites", "assets");
+const SPRITE_ASSET_CACHE_VERSION = "v3-hide-black-placeholder-assets";
 const appVersion = `v${require("../../../package.json").version}`;
 const IMAGE_HTTPS_AGENT = new https.Agent({ keepAlive: true, maxSockets: 12 });
 const RARITY_ORDER: SpriteRarity[] = ["rare", "epic", "legendary", "mythic", "special"];
@@ -852,6 +854,15 @@ export class FortniteSprites {
         return this._data?.families.flatMap(f => f.variants) || [];
     }
 
+    private getDisplayFamilies(families: SpriteFamily[]) {
+        return families
+            .map(family => ({
+                ...family,
+                variants: family.variants
+            }))
+            .filter(family => family.variants.length > 0);
+    }
+
     private findFamily(key: string | undefined): SpriteFamily | undefined {
         return this._data?.families.find(f => f.key === key);
     }
@@ -1117,12 +1128,14 @@ export class FortniteSprites {
     private async generateFamilyResponse(familyKey: string, ownerId: string, user: User | SpriteAuthor, displayName: string, editedAt?: string) {
         const family = this.findFamily(familyKey);
         if (!family) return { content: "Sprite family not found.", components: [] };
+        const displayFamily = this.getDisplayFamilies([family])[0];
+        if (!displayFamily) return { content: "That sprite family does not have released artwork yet.", components: this.generateOverviewComponents({}, ownerId) };
 
-        const image = await this.renderFamilyImage(family);
-        const attachment = new MessageAttachment(image, `sprites-family-${family.key}.png`);
+        const image = await this.renderFamilyImage(displayFamily);
+        const attachment = new MessageAttachment(image, `sprites-family-${displayFamily.key}.png`);
 
         const embed = new MessageEmbed()
-            .setColor(this.getFamilyColor(family) as any)
+            .setColor(this.getFamilyColor(displayFamily) as any)
             .setAuthor({ name: displayName, iconURL: this.getAuthorIconURL(user) })
             .setFooter({ text: this.buildFooterText(editedAt) })
             .setTimestamp();
@@ -1130,11 +1143,15 @@ export class FortniteSprites {
         return {
             embeds: [embed],
             files: [attachment],
-            components: this.generateFamilyComponents(family, ownerId)
+            components: this.generateFamilyComponents(displayFamily, ownerId)
         };
     }
 
     private async generateDetailResponse(family: SpriteFamily, variant: SpriteVariant, ownerId: string, user: User | SpriteAuthor, displayName: string, editedAt?: string) {
+        if (!await this.hasRenderableSpriteArtwork(variant)) {
+            return { content: "That sprite variant does not have released artwork yet.", components: this.generateOverviewComponents({}, ownerId) };
+        }
+
         const image = await this.renderVariantImage(family, variant);
         const attachment = new MessageAttachment(image, `sprites-variant-${variant.id}.png`);
 
@@ -1152,7 +1169,7 @@ export class FortniteSprites {
     }
     private generateOverviewComponents(state: SpriteBrowserState, ownerId: string) {
         const ownerSuffix = `|${ownerId}`;
-        const families = this._data?.families || [];
+        const families = this.getDisplayFamilies(this._data?.families || []);
         const selectedFamily = state.familyKey && families.some(f => f.key === state.familyKey) ? state.familyKey : undefined;
         const familyPage = state.familyPage || 0;
         const familiesPerPage = 25;
@@ -1289,7 +1306,7 @@ export class FortniteSprites {
             const { default: puppeteerModule } = await Function('return import("puppeteer")')();
             const browser = await puppeteerModule.launch({
                 headless: true,
-                executablePath: process.env.GOOGLE_CHROME_BIN || process.env.PUPPETEER_EXECUTABLE_PATH || (process.platform === 'linux' ? "/usr/bin/chromium" : undefined),
+                executablePath: this.getChromiumExecutablePath(),
                 args: ['--no-sandbox', '--disable-setuid-sandbox']
             });
             browser.on("disconnected", () => {
@@ -1315,6 +1332,18 @@ export class FortniteSprites {
             }
             throw error;
         }
+    }
+
+    private getChromiumExecutablePath(): string | undefined {
+        const configuredPath = process.env.GOOGLE_CHROME_BIN || process.env.PUPPETEER_EXECUTABLE_PATH;
+        if (configuredPath) return configuredPath;
+        if (process.platform !== "linux") return undefined;
+
+        return [
+            "/usr/bin/chromium",
+            "/usr/bin/chromium-browser",
+            "/snap/bin/chromium"
+        ].find(candidate => fs.existsSync(candidate));
     }
 
     private clearRenderCaches() {
@@ -1401,7 +1430,7 @@ export class FortniteSprites {
     }
 
     private getSpriteAssetDiskCachePath(imageUrl: string) {
-        const cacheKey = crypto.createHash("sha1").update(imageUrl).digest("hex");
+        const cacheKey = crypto.createHash("sha1").update(`${SPRITE_ASSET_CACHE_VERSION}:${imageUrl}`).digest("hex");
         return path.join(SPRITE_ASSET_CACHE_DIR, `${cacheKey}.txt`);
     }
 
@@ -1546,7 +1575,7 @@ export class FortniteSprites {
         const pending = this.pendingSpriteAssetLoads.get(imageUrl);
         if (pending) {
             const resolved = await pending;
-            return resolved || imageUrl;
+            return resolved || undefined;
         }
 
         const loadPromise = (async () => {
@@ -1557,26 +1586,36 @@ export class FortniteSprites {
                     return diskCached;
                 }
 
-                const correctedUrl = imageUrl.includes("fortnite.gg") ? imageUrl.replace(/\.png(\?.*)?$/i, ".webp$1") : imageUrl;
-                const proxyUrl = correctedUrl.includes("fortnite.gg")
-                    ? `https://wsrv.nl/?url=${encodeURIComponent(correctedUrl)}`
-                    : correctedUrl;
-
-                const res = await axios.get<ArrayBuffer>(proxyUrl, {
-                    responseType: "arraybuffer",
-                    timeout: 15000,
-                    httpsAgent: IMAGE_HTTPS_AGENT,
-                    headers: {
-                        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-                        "Accept": "image/webp,image/apng,image/*,*/*;q=0.8"
+                for (const candidateUrl of this.getSpriteImageUrlCandidates(imageUrl)) {
+                    try {
+                        const res = await axios.get<ArrayBuffer>(candidateUrl, {
+                            responseType: "arraybuffer",
+                            timeout: 15000,
+                            httpsAgent: IMAGE_HTTPS_AGENT,
+                            headers: {
+                                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+                                "Accept": "image/webp,image/png,image/apng,image/*,*/*;q=0.8"
+                            }
+                        });
+                        const contentType = String(res.headers["content-type"] || "").toLowerCase();
+                        if (!contentType.includes("image/")) {
+                            continue;
+                        }
+                        const imageBuffer = Buffer.from(res.data);
+                        if (!await this.isUsableSpriteArtwork(imageBuffer)) {
+                            continue;
+                        }
+                        const mimeType = contentType.includes("image/") ? contentType.split(";")[0] : "image/png";
+                        const dataUrl = `data:${mimeType};base64,${imageBuffer.toString("base64")}`;
+                        this.setSpriteAssetCacheEntry(imageUrl, dataUrl);
+                        await this.persistSpriteAssetToDisk(imageUrl, dataUrl);
+                        return dataUrl;
+                    } catch {
+                        // Try the next known Fortnite image extension before giving up.
                     }
-                });
-                const contentType = String(res.headers["content-type"] || "").toLowerCase();
-                const mimeType = contentType.includes("image/") ? contentType.split(";")[0] : "image/png";
-                const dataUrl = `data:${mimeType};base64,${Buffer.from(res.data).toString("base64")}`;
-                this.setSpriteAssetCacheEntry(imageUrl, dataUrl);
-                await this.persistSpriteAssetToDisk(imageUrl, dataUrl);
-                return dataUrl;
+                }
+
+                return null;
             } catch {
                 return null;
             }
@@ -1586,7 +1625,7 @@ export class FortniteSprites {
 
         this.pendingSpriteAssetLoads.set(imageUrl, loadPromise);
         const resolved = await loadPromise;
-        return resolved || imageUrl;
+        return resolved || undefined;
     }
 
     private async prewarmSpriteImages(imageUrls: Array<string | undefined>) {
@@ -1594,6 +1633,61 @@ export class FortniteSprites {
         await this.forEachConcurrent(uniqueUrls, SPRITE_IMAGE_PREWARM_CONCURRENCY, async (url) => {
             await this.resolveSpriteImageSrc(url);
         });
+    }
+
+    private async hasRenderableSpriteArtwork(variant: SpriteVariant) {
+        return !!await this.resolveSpriteImageSrc(variant.imageUrl);
+    }
+
+    private async isUsableSpriteArtwork(imageBuffer: Buffer) {
+        try {
+            const image = await loadImage(imageBuffer);
+            const canvas = createCanvas(image.width, image.height);
+            const ctx = canvas.getContext("2d");
+            ctx.drawImage(image, 0, 0);
+
+            const pixels = ctx.getImageData(0, 0, image.width, image.height).data;
+            let opaquePixels = 0;
+            let darkPixels = 0;
+            let colorfulPixels = 0;
+            let lumaTotal = 0;
+
+            for (let index = 0; index < pixels.length; index += 4) {
+                const red = pixels[index];
+                const green = pixels[index + 1];
+                const blue = pixels[index + 2];
+                const alpha = pixels[index + 3];
+                if (alpha < 24) continue;
+
+                opaquePixels += 1;
+                const max = Math.max(red, green, blue);
+                const min = Math.min(red, green, blue);
+                const saturation = max === 0 ? 0 : (max - min) / max;
+                const luma = 0.2126 * red + 0.7152 * green + 0.0722 * blue;
+
+                lumaTotal += luma;
+                if (max < 45) darkPixels += 1;
+                if (saturation > 0.18 && max > 55) colorfulPixels += 1;
+            }
+
+            if (opaquePixels === 0) return false;
+
+            const darkRatio = darkPixels / opaquePixels;
+            const colorfulRatio = colorfulPixels / opaquePixels;
+            const averageLuma = lumaTotal / opaquePixels;
+
+            return !(darkRatio > 0.98 && colorfulRatio < 0.01 && averageLuma < 8);
+        } catch {
+            return false;
+        }
+    }
+
+    private getSpriteImageUrlCandidates(imageUrl: string): string[] {
+        if (!imageUrl.includes("fortnite.gg")) return [imageUrl];
+
+        const webpUrl = imageUrl.replace(/\.(?:png|webp)(\?.*)?$/i, ".webp$1");
+        const pngUrl = imageUrl.replace(/\.(?:png|webp)(\?.*)?$/i, ".png$1");
+        return Array.from(new Set([webpUrl, imageUrl, pngUrl]));
     }
 
     private async renderHtmlToBuffer(html: string, width: number, height: number): Promise<Buffer> {
@@ -1649,11 +1743,7 @@ export class FortniteSprites {
     }
 
     private renderSpriteThumb(imageUrl: string | undefined, className: string, fallback = "No asset") {
-        const correctedUrl = imageUrl && imageUrl.includes("fortnite.gg") ? imageUrl.replace(/\.png(\?.*)?$/i, ".webp$1") : imageUrl;
-        const proxyUrl = correctedUrl && correctedUrl.includes("fortnite.gg")
-            ? `https://wsrv.nl/?url=${encodeURIComponent(correctedUrl)}`
-            : correctedUrl;
-        const resolvedSrc = imageUrl ? this.spriteAssetCache.get(imageUrl)?.src || proxyUrl : undefined;
+        const resolvedSrc = imageUrl ? this.spriteAssetCache.get(imageUrl)?.src : undefined;
         return `
             <div class="sprite-thumb ${className}">
                 ${resolvedSrc ? `<img src="${this.escapeHtml(resolvedSrc)}" alt="">` : `<span class="metric-label">${this.escapeHtml(fallback)}</span>`}
@@ -1741,7 +1831,7 @@ export class FortniteSprites {
                         text-rendering: optimizeLegibility;
                     }
                     img { display: block; max-width: 100%; }
-                    .canvas {
+                    .sprite-render-root {
                         width: 100%;
                         height: 100%;
                         padding: 26px;
@@ -1979,19 +2069,26 @@ export class FortniteSprites {
     private async renderOverviewImage(families: SpriteFamily[], state: SpriteBrowserState): Promise<Buffer> {
         const cacheKey = `overview:${this.renderUiFingerprint}:${this._data?.fetchedAt}:${state.variantFilter || "all"}:${state.rarityFilter || "all"}:${state.searchQuery || ""}`;
         return this.getOrRenderImage(cacheKey, async () => {
-            const width = 1700;
-            const height = Math.max(1300, 390 + Math.max(families.length, 1) * 84);
-            const variants = families.flatMap(family => family.variants.map(variant => ({ family, variant })));
-            await this.prewarmSpriteImages(variants.map(({ variant }) => variant.imageUrl));
+            const displayFamilies = this.getDisplayFamilies(families);
+            await this.prewarmSpriteImages(displayFamilies.flatMap(family => family.variants.map(variant => variant.imageUrl)));
+            const renderFamilies = displayFamilies
+                .map(family => ({
+                    ...family,
+                    variants: family.variants.filter(variant => this.spriteAssetCache.has(variant.imageUrl))
+                }))
+                .filter(family => family.variants.length > 0);
+            const variants = renderFamilies.flatMap(family => family.variants.map(variant => ({ family, variant })));
+            const variantColumns = this.getVariantNames(renderFamilies);
+            const width = 2100;
+            const height = Math.max(1300, 520 + Math.max(renderFamilies.length, 1) * 92);
             const tags = [
                 state.searchQuery ? `Search: "${state.searchQuery}"` : null,
                 state.variantFilter && state.variantFilter !== "all" ? this.variantLabel(state.variantFilter) : null,
                 state.rarityFilter && state.rarityFilter !== "all" ? this.titleCase(state.rarityFilter) : null
             ].filter(Boolean).join(" / ") || "All variants";
-            const variantColumns = this.getVariantNames();
 
             const html = this.buildRenderDocument(`
-            <div class="canvas">
+            <div class="sprite-render-root">
                 <div class="shell">
                     <div class="content overview-layout">
                         <section class="page-head">
@@ -2001,7 +2098,7 @@ export class FortniteSprites {
                                 <p class="lede">${this.escapeHtml(this.describeOverviewState(state) || "All visible sprites at a glance.")}</p>
                             </div>
                             <div class="page-meta">
-                                ${this.renderMetaChip(`${families.length} families`)}
+                                ${this.renderMetaChip(`${renderFamilies.length} families`)}
                                 ${this.renderMetaChip(`${variants.length} shown`)}
                                 ${this.renderMetaChip(tags)}
                             </div>
@@ -2010,7 +2107,7 @@ export class FortniteSprites {
                         <section class="panel overview-panel">
                             <div class="overview-board">
                                 <div class="overview-table" style="--variant-count:${variantColumns.length}">
-                                    ${families.length === 0 ? `
+                                    ${renderFamilies.length === 0 ? `
                                         <article class="empty-state">
                                             <h3>No sprites found</h3>
                                             <p>Try a broader search, reset to all sprites, or pick a family from the menu.</p>
@@ -2020,7 +2117,7 @@ export class FortniteSprites {
                                             ${variantColumns.map(variantName => `<span>${this.escapeHtml(this.variantLabel(variantName))}</span>`).join("")}
                                         </div>
                                         <div class="overview-family-list">
-                                            ${families.map(family => {
+                                            ${renderFamilies.map(family => {
                 return `
                                                     <article class="family-row">
                                                         ${variantColumns.map(variantName => {
@@ -2179,7 +2276,7 @@ export class FortniteSprites {
             const bannerChance = this.formatChance(variant);
 
             const html = this.buildRenderDocument(`
-            <div class="canvas">
+            <div class="sprite-render-root">
                 <div class="shell">
                     <div class="content variant-layout">
                         <section class="page-head">
@@ -2460,7 +2557,8 @@ export class FortniteSprites {
             const width = 1200;
             const height = 800;
             await this.prewarmSpriteImages(family.variants.map(variant => variant.imageUrl));
-            const sortedVariants = [...family.variants].sort((a, b) => {
+            const renderVariants = family.variants.filter(variant => this.spriteAssetCache.has(variant.imageUrl));
+            const sortedVariants = [...renderVariants].sort((a, b) => {
                 if (a.variant === "Base" && b.variant !== "Base") return -1;
                 if (a.variant !== "Base" && b.variant === "Base") return 1;
                 return b.chancePercent - a.chancePercent || a.id - b.id;
@@ -2468,7 +2566,7 @@ export class FortniteSprites {
             const baseVariant = sortedVariants.find(variant => variant.variant === "Base") || sortedVariants[0];
 
             const html = this.buildRenderDocument(`
-            <div class="canvas">
+            <div class="sprite-render-root">
                 <div class="shell">
                     <div class="content family-layout">
                         <section class="page-head">
@@ -2479,7 +2577,7 @@ export class FortniteSprites {
                                 <p class="lede">${this.escapeHtml(family.location)}</p>
                             </div>
                             <div class="page-meta">
-                                ${this.renderMetaChip(`${family.variants.length} variants`)}
+                                ${this.renderMetaChip(`${sortedVariants.length} variants`)}
                             </div>
                         </section>
 
@@ -2488,7 +2586,7 @@ export class FortniteSprites {
                                 ${this.renderSpriteThumb(baseVariant?.imageUrl, "featured-thumb")}
                                 <div class="family-summary">
                                     ${baseVariant ? this.renderRarityPill(baseVariant.rarity) : ""}
-                                    <span>${family.variants.length} variants</span>
+                                    <span>${sortedVariants.length} variants</span>
                                 </div>
                                 <div class="family-copy">
                                     <h3 class="copy-title">Effect</h3>
@@ -2726,9 +2824,10 @@ export class FortniteSprites {
         return variant === "Candy" ? "Gummy" : variant;
     }
 
-    private getVariantNames() {
-        const names = Array.from(new Set(this.getAllVariants().map(variant => variant.variant)));
-        const preferredOrder = ["Base", "Gold", "Candy", "Galaxy"];
+    private getVariantNames(families?: SpriteFamily[]) {
+        const variants = families ? families.flatMap(family => family.variants) : this.getDisplayFamilies(this._data?.families || []).flatMap(family => family.variants);
+        const names = Array.from(new Set(variants.map(variant => variant.variant)));
+        const preferredOrder = ["Base", "Gold", "Candy", "Galaxy", "Holofoil"];
         return names.sort((a, b) => {
             const aIndex = preferredOrder.indexOf(a);
             const bIndex = preferredOrder.indexOf(b);

--- a/src/Fortnite/FortniteSprites/spriteData.json
+++ b/src/Fortnite/FortniteSprites/spriteData.json
@@ -1,23 +1,23 @@
 {
-  "fetchedAt": "2026-06-26T06:53:12.823Z",
-  "totalSprites": 61,
-  "totalLevels": 305,
+  "fetchedAt": "2026-07-09T13:24:12.204Z",
+  "totalSprites": 146,
+  "totalLevels": 66,
   "families": [
     {
       "key": "water",
-      "displayName": "Water Sprite",
+      "displayName": "Water",
       "effectSummary": "Replenish shields while standing in water!",
       "levelScaling": "Increases in power at each Level Up: 2 Shield -> 3 Shield -> 4 Shield -> 5 Shield -> 6 Shield per tick",
       "location": "Spotted near rivers and beaches",
       "variants": [
         {
           "id": 1,
-          "name": "Water Sprite",
+          "name": "Water",
           "rarity": "rare",
           "chancePercent": 12.83,
           "chanceLabel": "12.83%",
-          "starter": true,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Water_Unvault_Ch7S3_ui_L.webp",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Water_Unvault_Ch7S3_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 12.83,
@@ -31,12 +31,12 @@
         },
         {
           "id": 4,
-          "name": "Gold Water Sprite",
+          "name": "Gold Water",
           "rarity": "special",
           "chancePercent": 0.7,
           "chanceLabel": "0.7%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Water_Gold_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Water_Gold_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.7,
@@ -51,12 +51,12 @@
         },
         {
           "id": 2,
-          "name": "Gummy Water Sprite",
+          "name": "Gummy Water",
           "rarity": "special",
           "chancePercent": 0.28,
           "chanceLabel": "0.28%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Water_Candy_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Water_Candy_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.28,
@@ -71,12 +71,12 @@
         },
         {
           "id": 3,
-          "name": "Galaxy Water Sprite",
+          "name": "Galaxy Water",
           "rarity": "special",
           "chancePercent": 0.28,
           "chanceLabel": "0.28%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Water_Galaxy_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Water_Galaxy_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.28,
@@ -86,26 +86,104 @@
           "variant": "Galaxy",
           "summonCost": 4000,
           "effectText": "Replenish shields while standing in water!",
-          "specialEffectText": "Gain 30% more Ammunition when looting",
+          "specialEffectText": "Gain 30% more Ammo whenever picked up in the world",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 43,
+          "name": "Holofoil Water",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Water_Holofoil_ui_L.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Holofoil",
+          "summonCost": 0,
+          "effectText": "Replenish shields while standing in water!",
+          "specialEffectText": "5% chance for your squad to find rare Sprite Variants from looting chests",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 76,
+          "name": "Gem Water",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Water_Gem_ui_L.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Gem",
+          "summonCost": 0,
+          "effectText": "Replenish shields while standing in water!",
+          "specialEffectText": "Take 30% less Fall damage",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 83,
+          "name": "Cube Water",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_water_cube.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Cube",
+          "summonCost": 0,
+          "effectText": "Replenish shields while standing in water!",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 84,
+          "name": "Quack Water",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_water_quack.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Quack",
+          "summonCost": 0,
+          "effectText": "Replenish shields while standing in water!",
           "detailStatus": "complete"
         }
       ]
     },
     {
       "key": "earth",
-      "displayName": "Earth Sprite",
+      "displayName": "Earth",
       "effectSummary": "You have a chance to find additional rare items when opening chests.",
       "levelScaling": "Chance increases at each Level Up: 10% -> 12.5% -> 15% -> 17.5% -> 20% chance to find additional rare loot",
       "location": "Found wandering around forests and wooded regions",
       "variants": [
         {
           "id": 5,
-          "name": "Earth Sprite",
+          "name": "Earth",
           "rarity": "rare",
           "chancePercent": 12.83,
           "chanceLabel": "12.83%",
-          "starter": true,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Earth_Ch7S3_UI_L.webp",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Earth_Ch7S3_UI_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 12.83,
@@ -119,12 +197,12 @@
         },
         {
           "id": 8,
-          "name": "Gold Earth Sprite",
+          "name": "Gold Earth",
           "rarity": "special",
           "chancePercent": 0.7,
           "chanceLabel": "0.7%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Earth_Gold_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Earth_Gold_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.7,
@@ -139,12 +217,12 @@
         },
         {
           "id": 6,
-          "name": "Gummy Earth Sprite",
+          "name": "Gummy Earth",
           "rarity": "special",
           "chancePercent": 0.28,
           "chanceLabel": "0.28%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Earth_Candy_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Earth_Candy_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.28,
@@ -159,12 +237,12 @@
         },
         {
           "id": 7,
-          "name": "Galaxy Earth Sprite",
+          "name": "Galaxy Earth",
           "rarity": "special",
           "chancePercent": 0.28,
           "chanceLabel": "0.28%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Earth_Galaxy_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Earth_Galaxy_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.28,
@@ -174,26 +252,104 @@
           "variant": "Galaxy",
           "summonCost": 4000,
           "effectText": "You have a chance to find additional rare items when opening chests.",
-          "specialEffectText": "Gain 30% more Ammunition when looting",
+          "specialEffectText": "Gain 30% more Ammo whenever picked up in the world",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 45,
+          "name": "Gem Earth",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Earth_Gem_ui_L.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Gem",
+          "summonCost": 0,
+          "effectText": "You have a chance to find additional rare items when opening chests.",
+          "specialEffectText": "Take 30% less Fall damage",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 85,
+          "name": "Holofoil Earth",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_earth_holofoil.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Holofoil",
+          "summonCost": 0,
+          "effectText": "You have a chance to find additional rare items when opening chests.",
+          "specialEffectText": "5% chance for your squad to find rare Sprite Variants from looting chests",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 86,
+          "name": "Cube Earth",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_earth_cube.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Cube",
+          "summonCost": 0,
+          "effectText": "You have a chance to find additional rare items when opening chests.",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 87,
+          "name": "Quack Earth",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_earth_quack.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Quack",
+          "summonCost": 0,
+          "effectText": "You have a chance to find additional rare items when opening chests.",
           "detailStatus": "complete"
         }
       ]
     },
     {
       "key": "fire",
-      "displayName": "Fire Sprite",
+      "displayName": "Fire",
       "effectSummary": "Creates a fiery burst when you deal enough damage to an enemy!",
       "levelScaling": "Required damage decreases at each Level Up: 150 Damage -> 125 Damage -> 100 Damage -> 75 Damage -> 50 Damage to trigger",
       "location": "Located near urban areas",
       "variants": [
         {
           "id": 9,
-          "name": "Fire Sprite",
+          "name": "Fire",
           "rarity": "rare",
           "chancePercent": 12.45,
           "chanceLabel": "12.45%",
-          "starter": true,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Fire_Unvault_Ch7S3_ui_L.webp",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Fire_Unvault_Ch7S3_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 12.45,
@@ -207,12 +363,12 @@
         },
         {
           "id": 10,
-          "name": "Gummy Fire Sprite",
+          "name": "Gummy Fire",
           "rarity": "special",
           "chancePercent": 0.68,
           "chanceLabel": "0.68%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Fire_Candy_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Fire_Candy_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.68,
@@ -227,12 +383,12 @@
         },
         {
           "id": 12,
-          "name": "Gold Fire Sprite",
+          "name": "Gold Fire",
           "rarity": "special",
           "chancePercent": 0.68,
           "chanceLabel": "0.68%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Fire_Gold_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Fire_Gold_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.68,
@@ -247,12 +403,12 @@
         },
         {
           "id": 11,
-          "name": "Galaxy Fire Sprite",
+          "name": "Galaxy Fire",
           "rarity": "special",
           "chancePercent": 0.27,
           "chanceLabel": "0.27%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Fire_Galaxy_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Fire_Galaxy_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.27,
@@ -262,26 +418,104 @@
           "variant": "Galaxy",
           "summonCost": 4000,
           "effectText": "Creates a fiery burst when you deal enough damage to an enemy!",
-          "specialEffectText": "Gain 30% more Ammunition when looting",
+          "specialEffectText": "Gain 30% more Ammo whenever picked up in the world",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 46,
+          "name": "Holofoil Fire",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Fire_Holofoil_ui_L.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Holofoil",
+          "summonCost": 0,
+          "effectText": "Creates a fiery burst when you deal enough damage to an enemy!",
+          "specialEffectText": "5% chance for your squad to find rare Sprite Variants from looting chests",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 88,
+          "name": "Gem Fire",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_fire_gem.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Gem",
+          "summonCost": 0,
+          "effectText": "Creates a fiery burst when you deal enough damage to an enemy!",
+          "specialEffectText": "Take 30% less Fall damage",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 89,
+          "name": "Cube Fire",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_fire_cube.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Cube",
+          "summonCost": 0,
+          "effectText": "Creates a fiery burst when you deal enough damage to an enemy!",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 90,
+          "name": "Quack Fire",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_fire_quack.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Quack",
+          "summonCost": 0,
+          "effectText": "Creates a fiery burst when you deal enough damage to an enemy!",
           "detailStatus": "complete"
         }
       ]
     },
     {
       "key": "duck",
-      "displayName": "Duck Sprite",
+      "displayName": "Duck",
       "effectSummary": "Emoting or Jamming replenishes shields.",
       "levelScaling": "Increases in power at each Level Up: 2 Shield -> 3 Shield -> 4 Shield -> 6 Shield -> 8 Shield per tick",
       "location": "Found in the vault of a certain business mogul",
       "variants": [
         {
           "id": 13,
-          "name": "Duck Sprite",
+          "name": "Duck",
           "rarity": "epic",
           "chancePercent": 5.74,
           "chanceLabel": "5.74%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Duck_Default_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Duck_Default_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 5.74,
@@ -295,12 +529,12 @@
         },
         {
           "id": 16,
-          "name": "Gold Duck Sprite",
+          "name": "Gold Duck",
           "rarity": "special",
           "chancePercent": 0.07,
           "chanceLabel": "0.07%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Duck_Gold_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Duck_Gold_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.07,
@@ -315,12 +549,12 @@
         },
         {
           "id": 14,
-          "name": "Gummy Duck Sprite",
+          "name": "Gummy Duck",
           "rarity": "special",
           "chancePercent": 0.04,
           "chanceLabel": "0.04%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Duck_Candy_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Duck_Candy_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.04,
@@ -335,12 +569,12 @@
         },
         {
           "id": 15,
-          "name": "Galaxy Duck Sprite",
+          "name": "Galaxy Duck",
           "rarity": "special",
           "chancePercent": 0.02,
           "chanceLabel": "0.02%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Duck_Galaxy_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Duck_Galaxy_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.02,
@@ -350,26 +584,104 @@
           "variant": "Galaxy",
           "summonCost": 6000,
           "effectText": "Emoting or Jamming replenishes shields.",
-          "specialEffectText": "Gain 30% more Ammunition when looting",
+          "specialEffectText": "Gain 30% more Ammo whenever picked up in the world",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 44,
+          "name": "Gem Duck",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Duck_Gem_L.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Gem",
+          "summonCost": 0,
+          "effectText": "Emoting or Jamming replenishes shields.",
+          "specialEffectText": "Take 30% less Fall damage",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 91,
+          "name": "Holofoil Duck",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_duck_holofoil.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Holofoil",
+          "summonCost": 0,
+          "effectText": "Emoting or Jamming replenishes shields.",
+          "specialEffectText": "5% chance for your squad to find rare Sprite Variants from looting chests",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 92,
+          "name": "Cube Duck",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_duck_cube.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Cube",
+          "summonCost": 0,
+          "effectText": "Emoting or Jamming replenishes shields.",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 93,
+          "name": "Quack Duck",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_duck_quack.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Quack",
+          "summonCost": 0,
+          "effectText": "Emoting or Jamming replenishes shields.",
           "detailStatus": "complete"
         }
       ]
     },
     {
       "key": "ghost",
-      "displayName": "Ghost Sprite",
+      "displayName": "Ghost",
       "effectSummary": "Grants cloak for a duration upon reloading.",
       "levelScaling": "Increases in duration at each Level Up: 3 Seconds -> 3.5 Seconds -> 4 Seconds -> 4.5 Seconds -> 5 Seconds",
       "location": "Found in the world at nighttime",
       "variants": [
         {
           "id": 17,
-          "name": "Ghost Sprite",
+          "name": "Ghost",
           "rarity": "epic",
           "chancePercent": 5.74,
           "chanceLabel": "5.74%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Ghost_Unvault_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Ghost_Unvault_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 5.74,
@@ -383,12 +695,12 @@
         },
         {
           "id": 20,
-          "name": "Gold Ghost Sprite",
+          "name": "Gold Ghost",
           "rarity": "special",
           "chancePercent": 0.07,
           "chanceLabel": "0.07%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Ghost_Gold_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Ghost_Gold_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.07,
@@ -403,12 +715,12 @@
         },
         {
           "id": 18,
-          "name": "Gummy Ghost Sprite",
+          "name": "Gummy Ghost",
           "rarity": "special",
           "chancePercent": 0.04,
           "chanceLabel": "0.04%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Ghost_Candy_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Ghost_Candy_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.04,
@@ -423,12 +735,12 @@
         },
         {
           "id": 19,
-          "name": "Galaxy Ghost Sprite",
+          "name": "Galaxy Ghost",
           "rarity": "special",
           "chancePercent": 0.02,
           "chanceLabel": "0.02%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Ghost_Galaxy_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Ghost_Galaxy_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.02,
@@ -438,26 +750,104 @@
           "variant": "Galaxy",
           "summonCost": 6000,
           "effectText": "Grants cloak for a duration upon reloading.",
-          "specialEffectText": "Gain 30% more Ammunition when looting",
+          "specialEffectText": "Gain 30% more Ammo whenever picked up in the world",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 48,
+          "name": "Holofoil Ghost",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Ghost_Holo_L.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Holofoil",
+          "summonCost": 0,
+          "effectText": "Grants cloak for a duration upon reloading.",
+          "specialEffectText": "5% chance for your squad to find rare Sprite Variants from looting chests",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 94,
+          "name": "Gem Ghost",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_ghost_gem.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Gem",
+          "summonCost": 0,
+          "effectText": "Grants cloak for a duration upon reloading.",
+          "specialEffectText": "Take 30% less Fall damage",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 95,
+          "name": "Cube Ghost",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_ghost_cube.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Cube",
+          "summonCost": 0,
+          "effectText": "Grants cloak for a duration upon reloading.",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 96,
+          "name": "Quack Ghost",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_ghost_quack.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Quack",
+          "summonCost": 0,
+          "effectText": "Grants cloak for a duration upon reloading.",
           "detailStatus": "complete"
         }
       ]
     },
     {
       "key": "dream",
-      "displayName": "Dream Sprite",
+      "displayName": "Dream",
       "effectSummary": "Grants a random item at each level, exploding with legendary loot at Max Level.",
       "levelScaling": "Loot value increases at each Level Up!",
       "location": "Sometimes found sleeping in the storage crates",
       "variants": [
         {
           "id": 21,
-          "name": "Dream Sprite",
+          "name": "Dream",
           "rarity": "legendary",
           "chancePercent": 2.63,
           "chanceLabel": "2.63%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Sleepy_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Sleepy_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 2.63,
@@ -471,12 +861,12 @@
         },
         {
           "id": 24,
-          "name": "Gold Dream Sprite",
+          "name": "Gold Dream",
           "rarity": "special",
           "chancePercent": 0.03,
           "chanceLabel": "0.03%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Sleepy_Gold_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Sleepy_Gold_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.03,
@@ -491,12 +881,12 @@
         },
         {
           "id": 22,
-          "name": "Gummy Dream Sprite",
+          "name": "Gummy Dream",
           "rarity": "special",
           "chancePercent": 0.02,
           "chanceLabel": "0.02%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Sleepy_Candy_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Sleepy_Candy_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.02,
@@ -511,12 +901,12 @@
         },
         {
           "id": 23,
-          "name": "Galaxy Dream Sprite",
+          "name": "Galaxy Dream",
           "rarity": "special",
           "chancePercent": 0.01,
           "chanceLabel": "0.01%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Sleepy_Galaxy_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Sleepy_Galaxy_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.01,
@@ -526,26 +916,104 @@
           "variant": "Galaxy",
           "summonCost": 10000,
           "effectText": "Grants a random item at each level, exploding with legendary loot at Max Level.",
-          "specialEffectText": "Gain 30% more Ammunition when looting",
+          "specialEffectText": "Gain 30% more Ammo whenever picked up in the world",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 97,
+          "name": "Gem Dream",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_sleepy_gem.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Gem",
+          "summonCost": 0,
+          "effectText": "Grants a random item at each level, exploding with legendary loot at Max Level.",
+          "specialEffectText": "Take 30% less Fall damage",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 98,
+          "name": "Holofoil Dream",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_sleepy_holofoil.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Holofoil",
+          "summonCost": 0,
+          "effectText": "Grants a random item at each level, exploding with legendary loot at Max Level.",
+          "specialEffectText": "5% chance for your squad to find rare Sprite Variants from looting chests",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 99,
+          "name": "Cube Dream",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_sleepy_cube.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Cube",
+          "summonCost": 0,
+          "effectText": "Grants a random item at each level, exploding with legendary loot at Max Level.",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 100,
+          "name": "Quack Dream",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_sleepy_quack.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Quack",
+          "summonCost": 0,
+          "effectText": "Grants a random item at each level, exploding with legendary loot at Max Level.",
           "detailStatus": "complete"
         }
       ]
     },
     {
       "key": "punk",
-      "displayName": "Punk Sprite",
+      "displayName": "Punk",
       "effectSummary": "Possibly nothing... or infinitely something",
       "levelScaling": "No level scaling available.",
       "location": "Found rarely in Sprite Chests",
       "variants": [
         {
           "id": 25,
-          "name": "Punk Sprite",
+          "name": "Punk",
           "rarity": "legendary",
           "chancePercent": 1.98,
           "chanceLabel": "1.98%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Punk_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Punk_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 1.98,
@@ -559,12 +1027,12 @@
         },
         {
           "id": 28,
-          "name": "Gold Punk Sprite",
+          "name": "Gold Punk",
           "rarity": "special",
           "chancePercent": 0.02,
           "chanceLabel": "0.02%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Punk_Gold_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Punk_Gold_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.02,
@@ -579,12 +1047,12 @@
         },
         {
           "id": 26,
-          "name": "Gummy Punk Sprite",
+          "name": "Gummy Punk",
           "rarity": "special",
           "chancePercent": 0.01,
           "chanceLabel": "0.01%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Punk_Candy_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Punk_Candy_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.01,
@@ -599,41 +1067,119 @@
         },
         {
           "id": 27,
-          "name": "Galaxy Punk Sprite",
+          "name": "Galaxy Punk",
+          "rarity": "special",
+          "chancePercent": 0.01,
+          "chanceLabel": "0.01%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Punk_Galaxy_ui_L.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0.01,
+              "label": "0.01%"
+            }
+          },
+          "variant": "Galaxy",
+          "summonCost": 10000,
+          "effectText": "Possibly nothing... or infinitely something",
+          "specialEffectText": "Gain 30% more Ammo whenever picked up in the world",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 104,
+          "name": "Gem Punk",
           "rarity": "special",
           "chancePercent": 0,
           "chanceLabel": "0%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Punk_Galaxy_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_punk_gem.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0,
               "label": "0%"
             }
           },
-          "variant": "Galaxy",
-          "summonCost": 10000,
+          "variant": "Gem",
+          "summonCost": 0,
           "effectText": "Possibly nothing... or infinitely something",
-          "specialEffectText": "Gain 30% more Ammunition when looting",
+          "specialEffectText": "Take 30% less Fall damage",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 105,
+          "name": "Holofoil Punk",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_punk_holofoil.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Holofoil",
+          "summonCost": 0,
+          "effectText": "Possibly nothing... or infinitely something",
+          "specialEffectText": "5% chance for your squad to find rare Sprite Variants from looting chests",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 106,
+          "name": "Cube Punk",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_punk_cube.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Cube",
+          "summonCost": 0,
+          "effectText": "Possibly nothing... or infinitely something",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 107,
+          "name": "Quack Punk",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_punk_quack.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Quack",
+          "summonCost": 0,
+          "effectText": "Possibly nothing... or infinitely something",
           "detailStatus": "complete"
         }
       ]
     },
     {
       "key": "king",
-      "displayName": "King Sprite",
+      "displayName": "King",
       "effectSummary": "Your Pickaxe deals more damage.",
       "levelScaling": "Increases in damage at each Level Up: 30 -> 40 -> 60 -> 80 -> 120 bonus damage",
       "location": "Found rarely in Sprite Chests",
       "variants": [
         {
           "id": 29,
-          "name": "King Sprite",
+          "name": "King",
           "rarity": "epic",
           "chancePercent": 5.74,
           "chanceLabel": "5.74%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_King_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_King_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 5.74,
@@ -647,12 +1193,12 @@
         },
         {
           "id": 32,
-          "name": "Gold King Sprite",
+          "name": "Gold King",
           "rarity": "special",
           "chancePercent": 0.07,
           "chanceLabel": "0.07%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_King_Gold_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_King_Gold_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.07,
@@ -667,12 +1213,12 @@
         },
         {
           "id": 30,
-          "name": "Gummy King Sprite",
+          "name": "Gummy King",
           "rarity": "special",
           "chancePercent": 0.04,
           "chanceLabel": "0.04%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_King_Candy_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_King_Candy_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.04,
@@ -687,12 +1233,12 @@
         },
         {
           "id": 31,
-          "name": "Galaxy King Sprite",
+          "name": "Galaxy King",
           "rarity": "special",
           "chancePercent": 0.02,
           "chanceLabel": "0.02%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_King_Galaxy_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_King_Galaxy_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.02,
@@ -702,26 +1248,104 @@
           "variant": "Galaxy",
           "summonCost": 6000,
           "effectText": "Your Pickaxe deals more damage.",
-          "specialEffectText": "Gain 30% more Ammunition when looting",
+          "specialEffectText": "Gain 30% more Ammo whenever picked up in the world",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 73,
+          "name": "Holofoil King",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_King_Holofoil_ui_L.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Holofoil",
+          "summonCost": 0,
+          "effectText": "Your Pickaxe deals more damage.",
+          "specialEffectText": "5% chance for your squad to find rare Sprite Variants from looting chests",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 108,
+          "name": "Gem King",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_king_gem.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Gem",
+          "summonCost": 0,
+          "effectText": "Your Pickaxe deals more damage.",
+          "specialEffectText": "Take 30% less Fall damage",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 109,
+          "name": "Cube King",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_king_cube.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Cube",
+          "summonCost": 0,
+          "effectText": "Your Pickaxe deals more damage.",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 110,
+          "name": "Quack King",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_king_quack.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Quack",
+          "summonCost": 0,
+          "effectText": "Your Pickaxe deals more damage.",
           "detailStatus": "complete"
         }
       ]
     },
     {
       "key": "zero-point",
-      "displayName": "Zero Point Sprite",
+      "displayName": "Zero Point",
       "effectSummary": "Spawn a Shield Bubble Jr. when you use a healing item on yourself (excluding splashes and grenades).",
       "levelScaling": "Increases in duration at each Level Up: 6 Seconds -> 7 Seconds -> 8 Seconds -> 9 Seconds -> 10 Seconds",
       "location": "Found rarely in Sprite Chests",
       "variants": [
         {
           "id": 33,
-          "name": "Zero Point Sprite",
+          "name": "Zero Point",
           "rarity": "mythic",
           "chancePercent": 0.000098,
           "chanceLabel": "0.000098%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_ZeroPoint_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_ZeroPoint_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.000098,
@@ -735,12 +1359,12 @@
         },
         {
           "id": 36,
-          "name": "Gold Zero Point Sprite",
+          "name": "Gold Zero Point",
           "rarity": "special",
           "chancePercent": 0.0000012,
           "chanceLabel": "0.0000012%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_ZeroPoint_Gold_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_ZeroPoint_Gold_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.0000012,
@@ -755,12 +1379,12 @@
         },
         {
           "id": 34,
-          "name": "Gummy Zero Point Sprite",
+          "name": "Gummy Zero Point",
           "rarity": "special",
           "chancePercent": 6e-7,
           "chanceLabel": "0.0000006%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_ZeroPoint_Candy_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_ZeroPoint_Candy_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 6e-7,
@@ -775,12 +1399,12 @@
         },
         {
           "id": 35,
-          "name": "Galaxy Zero Point Sprite",
+          "name": "Galaxy Zero Point",
           "rarity": "special",
           "chancePercent": 4e-7,
           "chanceLabel": "0.0000004%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_ZeroPoint_Galaxy_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_ZeroPoint_Galaxy_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 4e-7,
@@ -790,26 +1414,104 @@
           "variant": "Galaxy",
           "summonCost": 15000,
           "effectText": "Spawn a Shield Bubble Jr. when you use a healing item on yourself (excluding splashes and grenades).",
-          "specialEffectText": "Gain 30% more Ammunition when looting",
+          "specialEffectText": "Gain 30% more Ammo whenever picked up in the world",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 82,
+          "name": "Gem Zero Point",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_ZeroPoint_Gem_ui_L.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Gem",
+          "summonCost": 0,
+          "effectText": "Spawn a Shield Bubble Jr. when you use a healing item on yourself (excluding splashes and grenades).",
+          "specialEffectText": "Take 30% less Fall damage",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 111,
+          "name": "Holofoil Zero Point",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_zero_point_holofoil.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Holofoil",
+          "summonCost": 0,
+          "effectText": "Spawn a Shield Bubble Jr. when you use a healing item on yourself (excluding splashes and grenades).",
+          "specialEffectText": "5% chance for your squad to find rare Sprite Variants from looting chests",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 112,
+          "name": "Cube Zero Point",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_zero_point_cube.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Cube",
+          "summonCost": 0,
+          "effectText": "Spawn a Shield Bubble Jr. when you use a healing item on yourself (excluding splashes and grenades).",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 113,
+          "name": "Quack Zero Point",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_ZeroPoint_Quack_ui_L.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Quack",
+          "summonCost": 0,
+          "effectText": "Spawn a Shield Bubble Jr. when you use a healing item on yourself (excluding splashes and grenades).",
           "detailStatus": "complete"
         }
       ]
     },
     {
       "key": "demon",
-      "displayName": "Demon Sprite",
+      "displayName": "Demon",
       "effectSummary": "Siphon some health and shields when you eliminate an opponent.",
       "levelScaling": "Increases in power at each Level Up: 10 Healing -> 15 Healing -> 20 Healing -> 25 Healing -> 30 Healing per elimination",
       "location": "Found rarely in Sprite Chests",
       "variants": [
         {
           "id": 37,
-          "name": "Demon Sprite",
+          "name": "Demon",
           "rarity": "epic",
           "chancePercent": 5.76,
           "chanceLabel": "5.76%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_RedDemon_Default_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_RedDemon_Default_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 5.76,
@@ -823,12 +1525,12 @@
         },
         {
           "id": 40,
-          "name": "Gold Demon Sprite",
+          "name": "Gold Demon",
           "rarity": "special",
           "chancePercent": 0.07,
           "chanceLabel": "0.07%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_RedDemon_Gold_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_RedDemon_Gold_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.07,
@@ -843,12 +1545,12 @@
         },
         {
           "id": 38,
-          "name": "Gummy Demon Sprite",
+          "name": "Gummy Demon",
           "rarity": "special",
           "chancePercent": 0.04,
           "chanceLabel": "0.04%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_RedDemon_Candy_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_RedDemon_Candy_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.04,
@@ -863,22 +1565,100 @@
         },
         {
           "id": 39,
-          "name": "Galaxy Demon Sprite",
+          "name": "Galaxy Demon",
+          "rarity": "special",
+          "chancePercent": 0.02,
+          "chanceLabel": "0.02%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_RedDemon_Galaxy_L.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0.02,
+              "label": "0.02%"
+            }
+          },
+          "variant": "Galaxy",
+          "summonCost": 6000,
+          "effectText": "Siphon some health and shields when you eliminate an opponent.",
+          "specialEffectText": "Gain 30% more Ammo whenever picked up in the world",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 47,
+          "name": "Gem Demon",
           "rarity": "special",
           "chancePercent": 0,
           "chanceLabel": "0%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_RedDemon_Galaxy_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_RedDemon_Gem_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0,
               "label": "0%"
             }
           },
-          "variant": "Galaxy",
-          "summonCost": 6000,
+          "variant": "Gem",
+          "summonCost": 0,
           "effectText": "Siphon some health and shields when you eliminate an opponent.",
-          "specialEffectText": "Gain 30% more Ammunition when looting",
+          "specialEffectText": "Take 30% less Fall damage",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 101,
+          "name": "Holofoil Demon",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_demon_holofoil.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Holofoil",
+          "summonCost": 0,
+          "effectText": "Siphon some health and shields when you eliminate an opponent.",
+          "specialEffectText": "5% chance for your squad to find rare Sprite Variants from looting chests",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 102,
+          "name": "Cube Demon",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_demon_cube.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Cube",
+          "summonCost": 0,
+          "effectText": "Siphon some health and shields when you eliminate an opponent.",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 103,
+          "name": "Quack Demon",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_demon_quack.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Quack",
+          "summonCost": 0,
+          "effectText": "Siphon some health and shields when you eliminate an opponent.",
           "detailStatus": "complete"
         }
       ]
@@ -897,7 +1677,7 @@
           "chancePercent": 1.01,
           "chanceLabel": "1.01%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_BurntPeanut_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_BurntPeanut_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 1.01,
@@ -913,19 +1693,19 @@
     },
     {
       "key": "boss",
-      "displayName": "Boss Sprite",
+      "displayName": "Boss",
       "effectSummary": "Grants an increase to your max HP and Shield.",
       "levelScaling": "Increases at each Level Up: 5 HP/Shield -> 10 HP/Shield -> 15 HP/Shield -> 20 HP/Shield -> 25 HP/Shield",
       "location": "Claimed from defeating a powerful adversary",
       "variants": [
         {
           "id": 49,
-          "name": "Boss Sprite",
+          "name": "Boss",
           "rarity": "legendary",
           "chancePercent": 2.63,
           "chanceLabel": "2.63%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Boss_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Boss_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 2.63,
@@ -939,12 +1719,12 @@
         },
         {
           "id": 50,
-          "name": "Gold Boss Sprite",
+          "name": "Gold Boss",
           "rarity": "special",
           "chancePercent": 0.03,
           "chanceLabel": "0.03%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Boss_Gold_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Boss_Gold_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.03,
@@ -959,12 +1739,12 @@
         },
         {
           "id": 51,
-          "name": "Gummy Boss Sprite",
+          "name": "Gummy Boss",
           "rarity": "special",
           "chancePercent": 0.02,
           "chanceLabel": "0.02%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Boss_Candy_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Boss_Candy_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.02,
@@ -979,12 +1759,12 @@
         },
         {
           "id": 52,
-          "name": "Galaxy Boss Sprite",
+          "name": "Galaxy Boss",
           "rarity": "special",
           "chancePercent": 0.01,
           "chanceLabel": "0.01%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Boss_Galaxy_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Boss_Galaxy_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.01,
@@ -994,26 +1774,270 @@
           "variant": "Galaxy",
           "summonCost": 0,
           "effectText": "Grants an increase to your max HP and Shield.",
-          "specialEffectText": "Gain 30% more Ammunition when looting",
+          "specialEffectText": "Gain 30% more Ammo whenever picked up in the world",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 124,
+          "name": "Gem Boss",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_boss_gem.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Gem",
+          "summonCost": 0,
+          "effectText": "Grants an increase to your max HP and Shield.",
+          "specialEffectText": "Take 30% less Fall damage",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 125,
+          "name": "Holofoil Boss",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_boss_holofoil.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Holofoil",
+          "summonCost": 0,
+          "effectText": "Grants an increase to your max HP and Shield.",
+          "specialEffectText": "5% chance for your squad to find rare Sprite Variants from looting chests",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 126,
+          "name": "Cube Boss",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_boss_cube.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Cube",
+          "summonCost": 0,
+          "effectText": "Grants an increase to your max HP and Shield.",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 127,
+          "name": "Quack Boss",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_boss_quack.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Quack",
+          "summonCost": 0,
+          "effectText": "Grants an increase to your max HP and Shield.",
+          "detailStatus": "complete"
+        }
+      ]
+    },
+    {
+      "key": "seven",
+      "displayName": "Seven",
+      "effectSummary": "Enemy player foot trails are visible in the world for your Squad.",
+      "levelScaling": "Duration increases at each Level Up: 10 Seconds -> 15 Seconds -> 20 Seconds -> 25 Seconds -> 30 Second foot trails",
+      "location": "Spotted near high and mountainous areas",
+      "variants": [
+        {
+          "id": 53,
+          "name": "Seven",
+          "rarity": "legendary",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Seven_ui_L.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Base",
+          "summonCost": 0,
+          "effectText": "Enemy player foot trails are visible in the world for your Squad.",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 54,
+          "name": "Gummy Seven",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Seven_Candy_ui_L.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Candy",
+          "summonCost": 0,
+          "effectText": "Enemy player foot trails are visible in the world for your Squad.",
+          "specialEffectText": "Gain 20% more Sprite Dust upon Extraction",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 55,
+          "name": "Galaxy Seven",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Seven_Galaxy_ui_L.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Galaxy",
+          "summonCost": 0,
+          "effectText": "Enemy player foot trails are visible in the world for your Squad.",
+          "specialEffectText": "Gain 30% more Ammo whenever picked up in the world",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 56,
+          "name": "Gold Seven",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Seven_Gold_ui_L.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Gold",
+          "summonCost": 0,
+          "effectText": "Enemy player foot trails are visible in the world for your Squad.",
+          "specialEffectText": "Gain 3x bonus XP from eliminations",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 57,
+          "name": "Holofoil Seven",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Seven_Holofoil_ui_L.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Holofoil",
+          "summonCost": 0,
+          "effectText": "Enemy player foot trails are visible in the world for your Squad.",
+          "specialEffectText": "5% chance for your squad to find rare Sprite Variants from looting chests",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 135,
+          "name": "Gem Seven",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_seven_gem.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Gem",
+          "summonCost": 0,
+          "effectText": "Enemy player foot trails are visible in the world for your Squad.",
+          "specialEffectText": "Take 30% less Fall damage",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 136,
+          "name": "Cube Seven",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_seven_cube.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Cube",
+          "summonCost": 0,
+          "effectText": "Enemy player foot trails are visible in the world for your Squad.",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 137,
+          "name": "Quack Seven",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_seven_quack.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Quack",
+          "summonCost": 0,
+          "effectText": "Enemy player foot trails are visible in the world for your Squad.",
           "detailStatus": "complete"
         }
       ]
     },
     {
       "key": "fishy",
-      "displayName": "Fishy Sprite",
+      "displayName": "Fishy",
       "effectSummary": "Swim speed greatly increased. Taking damage also briefly increases movement speed.",
       "levelScaling": "Increases in power at each Level Up: 25% Swim Speed / 10% Movement Speed -> 50% Swim Speed / 20% Movement Speed -> 100% Swim Speed / 30% Movement Speed -> 150% Swim Speed / 40% Movement Speed -> 200% Swim Speed / 50% Movement Speed Bonuses",
       "location": "Spotted near high and mountainous areas",
       "variants": [
         {
           "id": 58,
-          "name": "Fishy Sprite",
+          "name": "Fishy",
           "rarity": "rare",
           "chancePercent": 13.79,
           "chanceLabel": "13.79%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Fishy_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Fishy_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 13.79,
@@ -1027,12 +2051,12 @@
         },
         {
           "id": 61,
-          "name": "Gold Fishy Sprite",
+          "name": "Gold Fishy",
           "rarity": "special",
           "chancePercent": 0.17,
           "chanceLabel": "0.17%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Fishy_Gold_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Fishy_Gold_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.17,
@@ -1047,12 +2071,12 @@
         },
         {
           "id": 59,
-          "name": "Gummy Fishy Sprite",
+          "name": "Gummy Fishy",
           "rarity": "special",
           "chancePercent": 0.08,
           "chanceLabel": "0.08%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Fishy_Candy_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Fishy_Candy_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.08,
@@ -1067,12 +2091,12 @@
         },
         {
           "id": 60,
-          "name": "Galaxy Fishy Sprite",
+          "name": "Galaxy Fishy",
           "rarity": "special",
           "chancePercent": 0.06,
           "chanceLabel": "0.06%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Fishy_Galaxy_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Fishy_Galaxy_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.06,
@@ -1082,26 +2106,104 @@
           "variant": "Galaxy",
           "summonCost": 0,
           "effectText": "Swim speed greatly increased. Taking damage also briefly increases movement speed.",
-          "specialEffectText": "Gain 30% more Ammunition when looting",
+          "specialEffectText": "Gain 30% more Ammo whenever picked up in the world",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 114,
+          "name": "Gem Fishy",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_fishy_gem.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Gem",
+          "summonCost": 0,
+          "effectText": "Swim speed greatly increased. Taking damage also briefly increases movement speed.",
+          "specialEffectText": "Take 30% less Fall damage",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 115,
+          "name": "Holofoil Fishy",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_fishy_holofoil.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Holofoil",
+          "summonCost": 0,
+          "effectText": "Swim speed greatly increased. Taking damage also briefly increases movement speed.",
+          "specialEffectText": "5% chance for your squad to find rare Sprite Variants from looting chests",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 116,
+          "name": "Cube Fishy",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_fishy_cube.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Cube",
+          "summonCost": 0,
+          "effectText": "Swim speed greatly increased. Taking damage also briefly increases movement speed.",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 117,
+          "name": "Quack Fishy",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_fishy_quack.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Quack",
+          "summonCost": 0,
+          "effectText": "Swim speed greatly increased. Taking damage also briefly increases movement speed.",
           "detailStatus": "complete"
         }
       ]
     },
     {
       "key": "striker",
-      "displayName": "Striker Sprite",
-      "effectSummary": "Gain the Overdrive effect when you Mantle, Hurdle, or Wall Scramble. Duration increases at each Level Up: 6 Seconds -> 7 Seconds -> 8 Seconds -> 9 Seconds -> 10 Seconds of Overdrive",
-      "levelScaling": "No level scaling available.",
+      "displayName": "Striker",
+      "effectSummary": "Gain the Overdrive effect when you Mantle, Hurdle, or Wall Scramble.",
+      "levelScaling": "Duration increases at each Level Up: 6 Seconds -> 7 Seconds -> 8 Seconds -> 9 Seconds -> 10 Seconds of Overdrive",
       "location": "Spotted near high and mountainous areas",
       "variants": [
         {
           "id": 62,
-          "name": "Striker Sprite",
+          "name": "Striker",
           "rarity": "epic",
           "chancePercent": 5.74,
           "chanceLabel": "5.74%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Soccer_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Soccer_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 5.74,
@@ -1110,17 +2212,17 @@
           },
           "variant": "Base",
           "summonCost": 0,
-          "effectText": "Gain the Overdrive effect when you Mantle, Hurdle, or Wall Scramble. Duration increases at each Level Up: 6 Seconds -> 7 Seconds -> 8 Seconds -> 9 Seconds -> 10 Seconds of Overdrive",
+          "effectText": "Gain the Overdrive effect when you Mantle, Hurdle, or Wall Scramble.",
           "detailStatus": "complete"
         },
         {
           "id": 65,
-          "name": "Gold Striker Sprite",
+          "name": "Gold Striker",
           "rarity": "special",
           "chancePercent": 0.07,
           "chanceLabel": "0.07%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Soccer_Gold_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Soccer_Gold_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.07,
@@ -1129,18 +2231,18 @@
           },
           "variant": "Gold",
           "summonCost": 0,
-          "effectText": "Gain the Overdrive effect when you Mantle, Hurdle, or Wall Scramble. Duration increases at each Level Up: 6 Seconds -> 7 Seconds -> 8 Seconds -> 9 Seconds -> 10 Seconds of Overdrive",
+          "effectText": "Gain the Overdrive effect when you Mantle, Hurdle, or Wall Scramble.",
           "specialEffectText": "Gain 3x bonus XP from eliminations",
           "detailStatus": "complete"
         },
         {
           "id": 63,
-          "name": "Gummy Striker Sprite",
+          "name": "Gummy Striker",
           "rarity": "special",
           "chancePercent": 0.04,
           "chanceLabel": "0.04%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Soccer_Candy_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Soccer_Candy_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.04,
@@ -1149,18 +2251,18 @@
           },
           "variant": "Candy",
           "summonCost": 0,
-          "effectText": "Gain the Overdrive effect when you Mantle, Hurdle, or Wall Scramble. Duration increases at each Level Up: 6 Seconds -> 7 Seconds -> 8 Seconds -> 9 Seconds -> 10 Seconds of Overdrive",
+          "effectText": "Gain the Overdrive effect when you Mantle, Hurdle, or Wall Scramble.",
           "specialEffectText": "Gain 20% more Sprite Dust upon Extraction",
           "detailStatus": "complete"
         },
         {
           "id": 64,
-          "name": "Galaxy Striker Sprite",
+          "name": "Galaxy Striker",
           "rarity": "special",
           "chancePercent": 0.02,
           "chanceLabel": "0.02%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Soccer_Galaxy_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Soccer_Galaxy_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.02,
@@ -1169,27 +2271,105 @@
           },
           "variant": "Galaxy",
           "summonCost": 0,
-          "effectText": "Gain the Overdrive effect when you Mantle, Hurdle, or Wall Scramble. Duration increases at each Level Up: 6 Seconds -> 7 Seconds -> 8 Seconds -> 9 Seconds -> 10 Seconds of Overdrive",
-          "specialEffectText": "Gain 30% more Ammunition when looting",
+          "effectText": "Gain the Overdrive effect when you Mantle, Hurdle, or Wall Scramble.",
+          "specialEffectText": "Gain 30% more Ammo whenever picked up in the world",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 66,
+          "name": "Holofoil Striker",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Soccer_Holofoil_L.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Holofoil",
+          "summonCost": 0,
+          "effectText": "Gain the Overdrive effect when you Mantle, Hurdle, or Wall Scramble.",
+          "specialEffectText": "5% chance for your squad to find rare Sprite Variants from looting chests",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 118,
+          "name": "Gem Striker",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_soccer_gem.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Gem",
+          "summonCost": 0,
+          "effectText": "Gain the Overdrive effect when you Mantle, Hurdle, or Wall Scramble.",
+          "specialEffectText": "Take 30% less Fall damage",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 119,
+          "name": "Cube Striker",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_soccer_cube.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Cube",
+          "summonCost": 0,
+          "effectText": "Gain the Overdrive effect when you Mantle, Hurdle, or Wall Scramble.",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 120,
+          "name": "Quack Striker",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_soccer_quack.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Quack",
+          "summonCost": 0,
+          "effectText": "Gain the Overdrive effect when you Mantle, Hurdle, or Wall Scramble.",
           "detailStatus": "complete"
         }
       ]
     },
     {
       "key": "aura",
-      "displayName": "Aura Sprite",
+      "displayName": "Aura",
       "effectSummary": "Gain a Shock Rock charge when you deal enough damage to enemies!",
       "levelScaling": "Required damage decreases at each Level Up: 175 Damage -> 150 Damage -> 125 Damage -> 100 Damage -> 75 Damage to trigger",
       "location": "Spotted near high and mountainous areas",
       "variants": [
         {
           "id": 67,
-          "name": "Aura Sprite",
+          "name": "Aura",
           "rarity": "epic",
           "chancePercent": 5.74,
           "chanceLabel": "5.74%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Drifter_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Drifter_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 5.74,
@@ -1203,12 +2383,12 @@
         },
         {
           "id": 71,
-          "name": "Gold Aura Sprite",
+          "name": "Gold Aura",
           "rarity": "special",
           "chancePercent": 0.07,
           "chanceLabel": "0.07%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Drifter_Gold_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Drifter_Gold_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.07,
@@ -1223,12 +2403,12 @@
         },
         {
           "id": 68,
-          "name": "Gummy Aura Sprite",
+          "name": "Gummy Aura",
           "rarity": "special",
           "chancePercent": 0.04,
           "chanceLabel": "0.04%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Drifter_Candy_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Drifter_Candy_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.04,
@@ -1243,12 +2423,12 @@
         },
         {
           "id": 69,
-          "name": "Galaxy Aura Sprite",
+          "name": "Galaxy Aura",
           "rarity": "special",
           "chancePercent": 0.02,
           "chanceLabel": "0.02%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Drifter_Galaxy_ui_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Drifter_Galaxy_ui_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.02,
@@ -1258,26 +2438,270 @@
           "variant": "Galaxy",
           "summonCost": 0,
           "effectText": "Gain a Shock Rock charge when you deal enough damage to enemies!",
-          "specialEffectText": "Gain 30% more Ammunition when looting",
+          "specialEffectText": "Gain 30% more Ammo whenever picked up in the world",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 70,
+          "name": "Gem Aura",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Creature_Sprite_Drifter_Gem_ui_L.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Gem",
+          "summonCost": 0,
+          "effectText": "Gain a Shock Rock charge when you deal enough damage to enemies!",
+          "specialEffectText": "Take 30% less Fall damage",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 121,
+          "name": "Holofoil Aura",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_drifter_holofoil.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Holofoil",
+          "summonCost": 0,
+          "effectText": "Gain a Shock Rock charge when you deal enough damage to enemies!",
+          "specialEffectText": "5% chance for your squad to find rare Sprite Variants from looting chests",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 122,
+          "name": "Cube Aura",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_drifter_cube.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Cube",
+          "summonCost": 0,
+          "effectText": "Gain a Shock Rock charge when you deal enough damage to enemies!",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 123,
+          "name": "Quack Aura",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_drifter_quack.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Quack",
+          "summonCost": 0,
+          "effectText": "Gain a Shock Rock charge when you deal enough damage to enemies!",
+          "detailStatus": "complete"
+        }
+      ]
+    },
+    {
+      "key": "air",
+      "displayName": "Air",
+      "effectSummary": "Increases sprinting speed and jump height.",
+      "levelScaling": "Also nullifies fall damage.",
+      "location": "Spotted near high and mountainous areas",
+      "variants": [
+        {
+          "id": 74,
+          "name": "Air",
+          "rarity": "rare",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Air_Default_L.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Base",
+          "summonCost": 0,
+          "effectText": "Increases sprinting speed and jump height.",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 42,
+          "name": "Gold Air",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Air_Gold_L.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Gold",
+          "summonCost": 0,
+          "effectText": "Increases sprinting speed and jump height.",
+          "specialEffectText": "Gain 3x bonus XP from eliminations",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 72,
+          "name": "Gummy Air",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Air_Candy_L.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Candy",
+          "summonCost": 0,
+          "effectText": "Increases sprinting speed and jump height.",
+          "specialEffectText": "Gain 20% more Sprite Dust upon Extraction",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 75,
+          "name": "Galaxy Air",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Air_Galaxy_L.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Galaxy",
+          "summonCost": 0,
+          "effectText": "Increases sprinting speed and jump height.",
+          "specialEffectText": "Gain 30% more Ammo whenever picked up in the world",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 77,
+          "name": "Holofoil Air",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_Air_Holo_L.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Holofoil",
+          "summonCost": 0,
+          "effectText": "Increases sprinting speed and jump height.",
+          "specialEffectText": "5% chance for your squad to find rare Sprite Variants from looting chests",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 132,
+          "name": "Gem Air",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_air_gem.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Gem",
+          "summonCost": 0,
+          "effectText": "Increases sprinting speed and jump height.",
+          "specialEffectText": "Take 30% less Fall damage",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 133,
+          "name": "Cube Air",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_air_cube.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Cube",
+          "summonCost": 0,
+          "effectText": "Increases sprinting speed and jump height.",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 134,
+          "name": "Quack Air",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_air_quack.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Quack",
+          "summonCost": 0,
+          "effectText": "Increases sprinting speed and jump height.",
           "detailStatus": "complete"
         }
       ]
     },
     {
       "key": "grim",
-      "displayName": "Grim Sprite",
+      "displayName": "Grim",
       "effectSummary": "Players who attack you are marked for a duration.",
       "levelScaling": "Increases in duration at each Level Up: 3 Seconds -> 3.5 Seconds -> 4 Seconds -> 4.5 Seconds -> 5 Seconds",
       "location": "Found rarely in Sprite Chests",
       "variants": [
         {
           "id": 78,
-          "name": "Grim Sprite",
+          "name": "Grim",
           "rarity": "mythic",
           "chancePercent": 0.000098,
           "chanceLabel": "0.000098%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_GrimReaper_Default_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_GrimReaper_Default_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.000098,
@@ -1291,12 +2715,12 @@
         },
         {
           "id": 81,
-          "name": "Gold Grim Sprite",
+          "name": "Gold Grim",
           "rarity": "special",
           "chancePercent": 0.0000012,
           "chanceLabel": "0.0000012%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_GrimReaper_Gold_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_GrimReaper_Gold_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 0.0000012,
@@ -1311,12 +2735,12 @@
         },
         {
           "id": 79,
-          "name": "Gummy Grim Sprite",
+          "name": "Gummy Grim",
           "rarity": "special",
           "chancePercent": 6e-7,
           "chanceLabel": "0.0000006%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_GrimReaper_Candy_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_GrimReaper_Candy_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 6e-7,
@@ -1331,12 +2755,12 @@
         },
         {
           "id": 80,
-          "name": "Galaxy Grim Sprite",
+          "name": "Galaxy Grim",
           "rarity": "special",
           "chancePercent": 4e-7,
           "chanceLabel": "0.0000004%",
           "starter": false,
-          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_GrimReaper_Galaxy_L.webp",
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/T_Icon_BR_GrimReaper_Galaxy_L.png",
           "spawnRates": {
             "spriteChest": {
               "percent": 4e-7,
@@ -1346,11 +2770,283 @@
           "variant": "Galaxy",
           "summonCost": 0,
           "effectText": "Players who attack you are marked for a duration.",
-          "specialEffectText": "Gain 30% more Ammunition when looting",
+          "specialEffectText": "Gain 30% more Ammo whenever picked up in the world",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 128,
+          "name": "Gem Grim",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_grim_gem.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Gem",
+          "summonCost": 0,
+          "effectText": "Players who attack you are marked for a duration.",
+          "specialEffectText": "Take 30% less Fall damage",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 129,
+          "name": "Holofoil Grim",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_grim_holofoil.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Holofoil",
+          "summonCost": 0,
+          "effectText": "Players who attack you are marked for a duration.",
+          "specialEffectText": "5% chance for your squad to find rare Sprite Variants from looting chests",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 130,
+          "name": "Cube Grim",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_grim_cube.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Cube",
+          "summonCost": 0,
+          "effectText": "Players who attack you are marked for a duration.",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 131,
+          "name": "Quack Grim",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_grim_quack.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Quack",
+          "summonCost": 0,
+          "effectText": "Players who attack you are marked for a duration.",
+          "detailStatus": "complete"
+        }
+      ]
+    },
+    {
+      "key": "john-wick",
+      "displayName": "John Wick",
+      "effectSummary": "No effect description available.",
+      "levelScaling": "No level scaling available.",
+      "location": "Unknown",
+      "variants": [
+        {
+          "id": 138,
+          "name": "John Wick",
+          "rarity": "mythic",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_john_wick.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Base",
+          "summonCost": 0,
+          "effectText": "",
+          "detailStatus": "complete"
+        }
+      ]
+    },
+    {
+      "key": "batman",
+      "displayName": "Batman",
+      "effectSummary": "No effect description available.",
+      "levelScaling": "No level scaling available.",
+      "location": "Unknown",
+      "variants": [
+        {
+          "id": 139,
+          "name": "Batman",
+          "rarity": "mythic",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_batman.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Base",
+          "summonCost": 0,
+          "effectText": "",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 140,
+          "name": "Gold Batman",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_batman_gold.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Gold",
+          "summonCost": 0,
+          "effectText": "",
+          "specialEffectText": "Gain 3x bonus XP from eliminations",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 141,
+          "name": "Gummy Batman",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_batman_candy.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Candy",
+          "summonCost": 0,
+          "effectText": "",
+          "specialEffectText": "Gain 20% more Sprite Dust upon Extraction",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 142,
+          "name": "Galaxy Batman",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_batman_galaxy.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Galaxy",
+          "summonCost": 0,
+          "effectText": "",
+          "specialEffectText": "Gain 30% more Ammo whenever picked up in the world",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 143,
+          "name": "Gem Batman",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_batman_gem.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Gem",
+          "summonCost": 0,
+          "effectText": "",
+          "specialEffectText": "Take 30% less Fall damage",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 145,
+          "name": "Holofoil Batman",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_batman_holofoil.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Holofoil",
+          "summonCost": 0,
+          "effectText": "",
+          "specialEffectText": "5% chance for your squad to find rare Sprite Variants from looting chests",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 146,
+          "name": "Cube Batman",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_batman_cube.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Cube",
+          "summonCost": 0,
+          "effectText": "",
+          "detailStatus": "complete"
+        },
+        {
+          "id": 147,
+          "name": "Quack Batman",
+          "rarity": "special",
+          "chancePercent": 0,
+          "chanceLabel": "0%",
+          "starter": false,
+          "imageUrl": "https://fortnite.gg/img/x/sprites/icons/tmp_batman_quack.png",
+          "spawnRates": {
+            "spriteChest": {
+              "percent": 0,
+              "label": "0%"
+            }
+          },
+          "variant": "Quack",
+          "summonCost": 0,
+          "effectText": "",
           "detailStatus": "complete"
         }
       ]
     }
   ],
-  "contentFingerprint": "e6a39543702e47eed1effdbb9c59cf41f3a6d5c7bd330186587d225a5841ed53"
+  "contentFingerprint": "0a73edd46854d146aa5dd0c4fe63ccce82056ecf3f002753edbcb2fe8c1395c4"
 }

--- a/src/Fortnite/FortniteSprites/spriteDataSource.ts
+++ b/src/Fortnite/FortniteSprites/spriteDataSource.ts
@@ -87,7 +87,7 @@ function absoluteUrl(url: string | undefined): string {
 }
 
 function normalizeImageUrl(url: string): string {
-    return url;
+    return url.replace(/\.webp(\?.*)?$/i, ".png$1");
 }
 
 function normalizeText(value: string | undefined): string {
@@ -195,9 +195,11 @@ function parseListPage(html: string): { items: SpriteListItem[]; totalSprites: n
         return { current, max };
     }).get();
 
+    const reportedTotalSprites = parseNumber(statValues[0]?.max);
+
     return {
         items: items.sort((a, b) => a.id - b.id),
-        totalSprites: parseNumber(statValues[0]?.max) || items.length,
+        totalSprites: Math.max(reportedTotalSprites, items.length),
         totalLevels: parseNumber(statValues[1]?.max) || items.length * 5
     };
 }


### PR DESCRIPTION
## Summary
- Refreshes the Fortnite sprite scrape from Fortnite.gg and keeps the checked-in data stable by normalizing scraped `.webp` image URLs back to `.png` in `spriteData.json`.
- Updates runtime artwork loading so Fortnite.gg sprites are resolved as `.webp`, original URL, then `.png`. This keeps older `.png` data working while supporting current Fortnite.gg assets that only exist as `.webp`.
- Filters render output by actual usable artwork instead of filename guesses, so unreleased/placeholder sprites do not appear but valid `tmp_*` assets like Cube Dream can still render.
- Restores the original family/variant table style for the base overview and widens/tallens the HTML render so the current sprite set fits without flattening the card content.
- Reorders variant columns so Holofoil appears after Galaxy: `Base > Gold > Candy > Galaxy > Holofoil > Cube > Gem > Quack`.
- Adds a versioned local sprite-art cache and validates responses before caching, so stale bad cache entries and non-image responses are ignored.
- Improves Puppeteer/Chromium startup fallback for environments where Chromium is installed at `/usr/bin/chromium-browser` or `/snap/bin/chromium` instead of `/usr/bin/chromium`.
- Bumps the beta package patch version to `4.0.15`.

## How artwork filtering works
`isUsableSpriteArtwork` runs only against the downloaded sprite image bytes before they are cached/rendered. It does not render the Discord UI. The UI is still HTML/CSS in Puppeteer, screenshotted to a PNG.

Algorithm:
1. Decode the downloaded image with `loadImage`. If decode fails, the asset is not usable.
2. Draw that decoded image into a small in-memory canvas only so pixel data can be inspected.
3. Ignore transparent pixels with alpha below `24`.
4. Count opaque pixels, very dark pixels, colorful pixels, and total luma.
5. Reject images with no opaque pixels.
6. Reject only the black placeholder/silhouette case: more than `98%` of opaque pixels are very dark, less than `1%` are colorful, and average luma is below `8`.
7. Everything else is treated as usable artwork and can be cached/rendered.

This is why Cube Dream is allowed even though its filename starts with `tmp_`: the old filename-based filter was too broad, while the new filter checks whether the actual decoded artwork is a placeholder.

## What prewarm does
`prewarmSpriteImages` resolves all image URLs needed for a render before building the HTML screenshot. It de-dupes URLs, downloads/checks them with limited concurrency, tries the `.webp`/original/`.png` candidates, rejects bad placeholders, and populates the in-memory/disk cache.

After prewarm, the renderer only includes variants whose image URL successfully resolved into the cache. That prevents broken image boxes and keeps unreleased placeholder sprites out of the overview/family/variant renders.

## Verification
- `npm run fetch-sprites`
- `npx tsc --noEmit`
- Rendered full overview from PR code: `90` usable variants, `19` families
- Verified `.png` and `.webp` Fortnite.gg sprite URL candidates resolve correctly
- Verified Cube Dream renders while black placeholder assets are filtered